### PR TITLE
chore(ci): soften deploy sanity checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,12 +98,4 @@ jobs:
 
     - name: Sanity checks (temporary)
       run: |
-        echo "Verify gcloud authenticated and can access resources"
-        # show active account
-        gcloud auth list --filter=status:ACTIVE --format="value(account)" || true
-        # list bucket (non-destructive)
-        gcloud storage ls gs://sensor-data-to-bigquery || true
-        # list secret versions (non-sensitive metadata)
-        gcloud secrets versions list prod-db-credentials --project=${{ env.PROJECT_ID }} --limit=5 || true
-        # list BigQuery tables in dataset `sensors` (non-destructive)
-        bq --project_id=${{ env.PROJECT_ID }} ls --max_results=50 durham-weather-466502:sensors || true
+        bash scripts/ci_sanity_check.sh || true

--- a/scripts/ci_sanity_check.sh
+++ b/scripts/ci_sanity_check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID=${PROJECT_ID:-durham-weather-466502}
+DATASET="sensors"
+SECRET_ID="prod-db-credentials"
+BUCKET="sensor-data-to-bigquery"
+
+log() { echo "[sanity] $*"; }
+warn() { echo "[sanity][warn] $*"; }
+
+log "Active account:" || true
+gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null || warn "Could not list active account"
+
+log "List bucket top-level paths (non-fatal)"
+gcloud storage ls "gs://${BUCKET}" 2>/dev/null || warn "No access to bucket or bucket missing: ${BUCKET}"
+
+log "Secret metadata (optional)"
+if gcloud secrets describe "${SECRET_ID}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud secrets versions list "${SECRET_ID}" --project="${PROJECT_ID}" --limit=3 2>/dev/null || warn "Cannot list secret versions"
+else
+  warn "Secret ${SECRET_ID} not visible (expected if least-privileged)"
+fi
+
+log "BigQuery dataset metadata (optional)"
+if bq --project_id="${PROJECT_ID}" show "${PROJECT_ID}:${DATASET}" >/dev/null 2>&1; then
+  bq --project_id="${PROJECT_ID}" ls --max_results=20 "${PROJECT_ID}:${DATASET}" 2>/dev/null || warn "Cannot list tables (need metadataViewer)"
+else
+  warn "Dataset ${PROJECT_ID}:${DATASET} not visible"
+fi
+
+log "Sanity checks complete (no failures block build)."


### PR DESCRIPTION
Summary
Soften noisy permission-denied output in deploy workflow by extracting sanity checks to a script that treats missing IAM as warnings, not errors.

Changes
- Add scripts/ci_sanity_check.sh
- Replace inline shell block in .github/workflows/deploy.yml with script call

Motivation
Current deploy job logs show repeated PERMISSION_DENIED messages for Secret Manager and BigQuery dataset listing because the GitHub Actions service account lacks those bindings. This obscures real failures.

Next (separate infra PR): Add least-privilege IAM so warnings disappear entirely.

Risk
Low – only CI shell logic refactored; no functional runtime code altered.

Checklist
- [x] Script added with guarded checks
- [x] Workflow updated
- [ ] CI green
- [ ] Merge
