### PR TITLE
feat(merge): multi-source merge + daily automation

### DIFF
--- a/.github/workflows/daily-merge.yml
+++ b/.github/workflows/daily-merge.yml
@@ -1,0 +1,56 @@
+name: Daily Sensor Readings Merge
+
+on:
+  schedule:
+    - cron: '10 7 * * *' # 07:10 UTC daily, after verification (adjust as needed)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  BQ_PROJECT: durham-weather-466502
+  BQ_DATASET: sensors
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies (minimal)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Auth to GCP (OIDC)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_VERIFIER_SA }}
+          token_format: access_token
+
+      - name: Merge yesterday partitions (auto-detect staging)
+        run: |
+          YESTERDAY=$(date -u -d 'yesterday' +%F)
+          echo "Merging date $YESTERDAY"
+          python scripts/merge_sensor_readings.py \
+            --project "$BQ_PROJECT" \
+            --dataset "$BQ_DATASET" \
+            --date "$YESTERDAY" \
+            --auto-detect-staging \
+            --update-only-if-changed
+
+      - name: Upload merge logs (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: merge-logs
+          path: ./*.log

--- a/scripts/merge_backfill_range.py
+++ b/scripts/merge_backfill_range.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Backfill a date range into the consolidated sensor_readings table.
+
+Automatically discovers staging tables (per-source) and performs a MERGE per day.
+
+Example:
+  python scripts/merge_backfill_range.py \
+    --project durham-weather-466502 --dataset sensors \
+    --start 2025-08-21 --end 2025-08-28
+
+Environment fallbacks:
+  BQ_PROJECT, BQ_LOCATION
+"""
+from __future__ import annotations
+import argparse
+import datetime as dt
+import logging
+import os
+from google.cloud import bigquery
+from merge_sensor_readings import (
+    resolve_staging_tables, ensure_target_exists_from_reference, build_merge_sql  # type: ignore
+)  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(name)s: %(message)s')
+log = logging.getLogger("merge_backfill_range")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Backfill a date range with MERGE operations")
+    p.add_argument('--project', default=os.getenv('BQ_PROJECT'))
+    p.add_argument('--dataset', required=True)
+    p.add_argument('--start', required=True, help='Start date (YYYY-MM-DD) inclusive')
+    p.add_argument('--end', required=True, help='End date (YYYY-MM-DD) inclusive')
+    p.add_argument('--location', default=os.getenv('BQ_LOCATION', 'US'))
+    p.add_argument('--auto-detect-staging', action='store_true', default=True, help='Auto detect staging tables (default)')
+    p.add_argument('--staging-prefix', default='sensor_readings_')
+    p.add_argument('--staging-suffix', default='_raw')
+    p.add_argument('--staging-tables', default=None, help='Explicit comma list override')
+    p.add_argument('--target-table', default='sensor_readings')
+    p.add_argument('--update-only-if-changed', action='store_true')
+    return p.parse_args()
+
+
+def daterange(start: dt.date, end: dt.date):
+    cur = start
+    while cur <= end:
+        yield cur
+        cur += dt.timedelta(days=1)
+
+
+def main():
+    a = parse_args()
+    client = bigquery.Client(project=a.project, location=a.location)
+    # Build a lightweight args-like object for staging resolution reuse
+    from types import SimpleNamespace
+    tmp = SimpleNamespace(
+        staging_table=None,
+        staging_tables=a.staging_tables,
+        auto_detect_staging=(a.auto_detect_staging and not a.staging_tables),
+        staging_prefix=a.staging_prefix,
+        staging_suffix=a.staging_suffix,
+        target_table=a.target_table,
+    )
+    staging_tables = resolve_staging_tables(client, a.dataset, tmp)  # type: ignore
+    ensure_target_exists_from_reference(client, a.dataset, staging_tables[0], a.target_table)
+
+    for d in daterange(dt.date.fromisoformat(a.start), dt.date.fromisoformat(a.end)):
+        date_str = d.isoformat()
+        sql = build_merge_sql(client.project, a.dataset, staging_tables, a.target_table, a.update_only_if_changed)
+        cfg = bigquery.QueryJobConfig(query_parameters=[bigquery.ScalarQueryParameter('d', 'DATE', date_str)])
+        log.info("Merging date %s", date_str)
+        job = client.query(sql, job_config=cfg)
+        job.result()
+        log.info("Date %s merged (affected: %s)", date_str, job.num_dml_affected_rows)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/scripts/merge_sensor_readings.py
+++ b/scripts/merge_sensor_readings.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+from typing import List
 from google.cloud import bigquery
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(name)s: %(message)s')
@@ -33,38 +34,94 @@ def parse_args():
     p.add_argument('--dataset', required=True, help='BigQuery dataset ID')
     p.add_argument('--date', required=True, help='Date (YYYY-MM-DD) partition to merge')
     p.add_argument('--location', default=os.getenv('BQ_LOCATION', 'US'))
-    p.add_argument('--staging-table', default='staging_sensor_readings_raw', help='Staging table name (partitioned)')
+    # Single table (legacy behavior)
+    p.add_argument('--staging-table', default=None, help='Single staging table name (partitioned)')
+    # Multiple tables comma-separated
+    p.add_argument('--staging-tables', default=None, help='Comma separated list of staging tables to UNION ALL')
+    # Auto-detect tables with prefix (e.g. sensor_readings_ and suffix _raw)
+    p.add_argument('--auto-detect-staging', action='store_true', help='Auto-detect staging tables by prefix/suffix')
+    p.add_argument('--staging-prefix', default='sensor_readings_', help='Prefix used to auto-detect staging tables')
+    p.add_argument('--staging-suffix', default='_raw', help='Suffix used to auto-detect staging tables')
     p.add_argument('--target-table', default='sensor_readings', help='Target fact table name (partitioned)')
     p.add_argument('--update-only-if-changed', action='store_true', help='Skip UPDATE when value unchanged')
-    p.add_argument('--cleanup', action='store_true', help='Delete staging rows for the date after merge')
-    return p.parse_args()
+    p.add_argument('--cleanup', action='store_true', help='Delete staging rows for the date after merge (only for single-table legacy)')
+    args = p.parse_args()
+
+    # Normalize staging tables selection
+    selections = sum([
+        1 if args.staging_table else 0,
+        1 if args.staging_tables else 0,
+        1 if args.auto_detect_staging else 0
+    ])
+    if selections == 0:
+        # default legacy single table name
+        args.staging_table = 'staging_sensor_readings_raw'
+    elif selections > 1:
+        raise SystemExit("Specify only one of --staging-table, --staging-tables, or --auto-detect-staging")
+    return args
 
 
-def ensure_tables_exist(client: bigquery.Client, dataset: str, staging: str, target: str):
-    # Create target table if missing (schema copy from staging subset fields)
+def ensure_target_exists_from_reference(client: bigquery.Client, dataset: str, reference_staging: str, target: str):
+    """Create target table if missing using schema subset from a reference staging table."""
     try:
         client.get_table(f"{dataset}.{target}")
+        return
     except Exception:
-        try:
-            st = client.get_table(f"{dataset}.{staging}")
-            schema = [f for f in st.schema if f.name in {'timestamp','deployment_fk','metric_name','value'}]
-            tbl = bigquery.Table(f"{client.project}.{dataset}.{target}", schema=schema)
-            tbl.time_partitioning = bigquery.TimePartitioning(field='timestamp')
-            client.create_table(tbl)
-            log.info(f"Created target table {dataset}.{target}")
-        except Exception as e:  # pragma: no cover - defensive
-            log.error(f"Failed to create target table: {e}")
-            raise
+        pass
+    try:
+        st = client.get_table(f"{dataset}.{reference_staging}")
+    except Exception as e:
+        raise SystemExit(f"Reference staging table '{reference_staging}' not found to derive schema: {e}")
+    schema = [f for f in st.schema if f.name in {'timestamp','deployment_fk','metric_name','value'}]
+    if not schema:
+        raise SystemExit("Could not derive schema subset from staging table (required fields missing)")
+    tbl = bigquery.Table(f"{client.project}.{dataset}.{target}", schema=schema)
+    tbl.time_partitioning = bigquery.TimePartitioning(field='timestamp')
+    client.create_table(tbl)
+    log.info(f"Created target table {dataset}.{target} from schema of {reference_staging}")
 
 
-def build_merge_sql(project: str, dataset: str, staging: str, target: str, date: str, update_if_changed: bool) -> str:
+def resolve_staging_tables(client: bigquery.Client, dataset: str, args) -> List[str]:
+    if args.staging_table:
+        return [args.staging_table]
+    if args.staging_tables:
+        return [t.strip() for t in args.staging_tables.split(',') if t.strip()]
+    if args.auto_detect_staging:
+        prefix = args.staging_prefix
+        suffix = args.staging_suffix
+        detected = []
+        for tbl in client.list_tables(dataset):  # type: ignore[arg-type]
+            name = tbl.table_id
+            if not name.startswith(prefix):
+                continue
+            if suffix and not name.endswith(suffix):
+                continue
+            if name == args.target_table:
+                continue
+            detected.append(name)
+        if not detected:
+            raise SystemExit(f"Auto-detect found no staging tables with prefix '{prefix}' and suffix '{suffix}' in dataset {dataset}")
+        log.info("Auto-detected staging tables: %s", ', '.join(detected))
+        return detected
+    raise SystemExit("No staging table selection resolved (this should not happen)")
+
+
+def build_merge_sql(project: str, dataset: str, staging_tables: List[str], target: str, update_if_changed: bool) -> str:
     predicate = "T.value != S.value" if update_if_changed else "TRUE"
+    if len(staging_tables) == 1:
+        source_sql = f"SELECT timestamp, deployment_fk, metric_name, value FROM `{project}.{dataset}.{staging_tables[0]}` WHERE DATE(timestamp)=@d"
+        ref_for_comment = staging_tables[0]
+    else:
+        unions = []
+        for t in staging_tables:
+            unions.append(f"SELECT timestamp, deployment_fk, metric_name, value FROM `{project}.{dataset}.{t}` WHERE DATE(timestamp)=@d")
+        source_sql = "\nUNION ALL\n".join(unions)
+        ref_for_comment = ",".join(staging_tables)
     return f"""
+-- MERGE from staging tables: {ref_for_comment}
 MERGE `{project}.{dataset}.{target}` T
 USING (
-  SELECT timestamp, deployment_fk, metric_name, value
-  FROM `{project}.{dataset}.{staging}`
-  WHERE DATE(timestamp) = @d
+  {source_sql}
 ) S
 ON T.timestamp = S.timestamp
  AND T.deployment_fk = S.deployment_fk
@@ -74,22 +131,26 @@ WHEN NOT MATCHED THEN INSERT (timestamp, deployment_fk, metric_name, value) VALU
 """.strip()
 
 
-def merge_partition(client: bigquery.Client, args):
-    ensure_tables_exist(client, args.dataset, args.staging_table, args.target_table)
-    sql = build_merge_sql(client.project, args.dataset, args.staging_table, args.target_table, args.date, args.update_only_if_changed)
+def merge_partition(client: bigquery.Client, args, staging_tables: List[str]):
+    # create target if needed using first staging table as reference
+    ensure_target_exists_from_reference(client, args.dataset, staging_tables[0], args.target_table)
+    sql = build_merge_sql(client.project, args.dataset, staging_tables, args.target_table, args.update_only_if_changed)
     cfg = bigquery.QueryJobConfig(query_parameters=[bigquery.ScalarQueryParameter('d', 'DATE', args.date)])
-    log.info("Running MERGE...")
+    log.info("Running MERGE for %s from %d staging table(s)...", args.date, len(staging_tables))
     job = client.query(sql, job_config=cfg)
     job.result()
     log.info("MERGE complete. Affected rows: %s", job.num_dml_affected_rows)
 
 
-def cleanup_staging(client: bigquery.Client, args):
+def cleanup_staging(client: bigquery.Client, args, staging_tables: List[str]):
     if not args.cleanup:
         return
-    sql = f"DELETE FROM `{client.project}.{args.dataset}.{args.staging_table}` WHERE DATE(timestamp)=@d"
+    if len(staging_tables) != 1:
+        log.warning("Cleanup skipped: only supported for single staging table mode (got %d tables)", len(staging_tables))
+        return
+    sql = f"DELETE FROM `{client.project}.{args.dataset}.{staging_tables[0]}` WHERE DATE(timestamp)=@d"
     cfg = bigquery.QueryJobConfig(query_parameters=[bigquery.ScalarQueryParameter('d', 'DATE', args.date)])
-    log.info("Cleaning up staging partition %s...", args.date)
+    log.info("Cleaning up staging partition %s in %s...", args.date, staging_tables[0])
     job = client.query(sql, job_config=cfg)
     job.result()
     log.info("Cleanup complete (deleted rows: %s)", job.num_dml_affected_rows)
@@ -98,8 +159,9 @@ def cleanup_staging(client: bigquery.Client, args):
 def main():
     a = parse_args()
     client = bigquery.Client(project=a.project, location=a.location)
-    merge_partition(client, a)
-    cleanup_staging(client, a)
+    staging_tables = resolve_staging_tables(client, a.dataset, a)
+    merge_partition(client, a, staging_tables)
+    cleanup_staging(client, a, staging_tables)
 
 if __name__ == '__main__':  # pragma: no cover
     main()

--- a/scripts/run_cr_job.sh
+++ b/scripts/run_cr_job.sh
@@ -83,3 +83,18 @@ log "Fetching last 200 log lines (if available)"
 gcloud logging read "resource.type=cloud_run_job AND resource.labels.execution_name=$EXEC_ID" --project "$PROJECT_ID" --limit=200 --format="value(textPayload)" 2>/dev/null || log "No logs retrieved"
 
 log "Done."
+
+# Optional: trigger BigQuery merge backfill for yesterday (uncomment to enable)
+# if command -v python >/dev/null 2>&1; then
+#   YESTERDAY=$(date -u -d 'yesterday' +%F)
+#   PROJECT_ENV=${BQ_PROJECT:-$PROJECT_ID}
+#   if [ -n "${PROJECT_ENV}" ]; then
+#     echo "[run-job] (optional) Running merge backfill for $YESTERDAY"
+#     python scripts/merge_sensor_readings.py \
+#       --project "$PROJECT_ENV" \
+#       --dataset sensors \
+#       --date "$YESTERDAY" \
+#       --auto-detect-staging \
+#       --update-only-if-changed || echo "[run-job][warn] merge step failed (non-blocking)"
+#   fi
+# fi


### PR DESCRIPTION
Enhancements:
- merge_sensor_readings.py: support multi-source staging via --staging-tables, --auto-detect-staging, prefix/suffix detection, and legacy single-table mode.
- Added merge_backfill_range.py for backfilling a date range with auto-detected staging tables.
- Added daily-merge GitHub Actions workflow (07:10 UTC) to merge yesterday's partition automatically using auto-detect staging.
- Optional commented hook in run_cr_job.sh for on-demand merge post Cloud Run job.

Behavior:
- Backwards compatible unless new flags used.
- Target table auto-created from first staging table schema if missing.
- Cleanup only in single-table mode; multi-source skips destructive cleanup.

Next Steps (optional):
- Add pre-merge staging row count guard or alerting workflow if needed.
- Concurrency group if other BigQuery workflows overlap.

Testing:
- Local CLI help validated.
- No syntax errors detected in modified scripts.
