### PR TITLE
fix: Prevent daily summary from deleting historical data

### DIFF
--- a/scripts/backfill_daily_summaries.sh
+++ b/scripts/backfill_daily_summaries.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Backfill daily summaries after fixing the 7-day window bug
+# This will restore all historical data from sensor_readings_long
+
+set -e
+
+# Configuration
+PROJECT="${BQ_PROJECT:-durham-weather-466502}"
+DATASET="${BQ_DATASET:-sensors}"
+START_DATE="${1:-2024-07-04}"  # Default to July 4, 2024 (3+ months ago)
+END_DATE="${2:-2025-09-30}"     # Default to September 30, 2025
+
+echo "=========================================="
+echo "Daily Summary Backfill"
+echo "=========================================="
+echo "Project: $PROJECT"
+echo "Dataset: $DATASET"
+echo "Date Range: $START_DATE to $END_DATE"
+echo "=========================================="
+echo
+
+# Check if uv is available
+if ! command -v uv &> /dev/null; then
+    echo "Error: 'uv' command not found. Please install uv first."
+    exit 1
+fi
+
+# Get list of dates to backfill
+echo "Calculating dates to backfill..."
+dates=$(python3 -c "
+from datetime import datetime, timedelta
+start = datetime.strptime('$START_DATE', '%Y-%m-%d')
+end = datetime.strptime('$END_DATE', '%Y-%m-%d')
+current = start
+while current <= end:
+    print(current.strftime('%Y-%m-%d'))
+    current += timedelta(days=1)
+")
+
+# Count total dates
+total=$(echo "$dates" | wc -l | tr -d ' ')
+echo "Total dates to process: $total"
+echo
+
+# Process each date
+count=0
+failed=0
+for date in $dates; do
+    count=$((count + 1))
+    echo "[$count/$total] Processing $date..."
+    
+    if uv run python scripts/run_transformations.py \
+        --project "$PROJECT" \
+        --dataset "$DATASET" \
+        --date "$date" \
+        --dir transformations/sql \
+        --execute 2>&1 | grep -E "(Executed|Error)" || true; then
+        echo "  ✓ Completed $date"
+    else
+        echo "  ✗ Failed $date"
+        failed=$((failed + 1))
+    fi
+    
+    # Brief pause to avoid rate limiting
+    sleep 0.5
+done
+
+echo
+echo "=========================================="
+echo "Backfill Summary"
+echo "=========================================="
+echo "Total processed: $total"
+echo "Failed: $failed"
+echo "Success: $((total - failed))"
+echo "=========================================="
+
+if [ $failed -eq 0 ]; then
+    echo "✓ All dates backfilled successfully!"
+    exit 0
+else
+    echo "⚠ Some dates failed. Check logs above for details."
+    exit 1
+fi

--- a/transformations/sql/03_daily_summary.sql
+++ b/transformations/sql/03_daily_summary.sql
@@ -1,6 +1,6 @@
--- Daily summary aggregation with partition-aware DELETE+INSERT for 7-day window.
+-- Daily summary aggregation with partition-aware DELETE+INSERT.
+-- Uses @proc_date; safe to re-run for the same date.
 DECLARE proc_date DATE DEFAULT @proc_date;
-DECLARE start_date DATE DEFAULT DATE_SUB(proc_date, INTERVAL 6 DAY);
 
 -- Bootstrap table if missing
 CREATE TABLE IF NOT EXISTS `${PROJECT}.${DATASET}.sensor_readings_daily`
@@ -18,9 +18,9 @@ FROM `${PROJECT}.${DATASET}.sensor_readings_long`
 WHERE 1=0
 GROUP BY 1,2,3;
 
--- Refresh the 7-day window partitions
+-- Refresh only the partition for proc_date (not a rolling window)
 DELETE FROM `${PROJECT}.${DATASET}.sensor_readings_daily`
-WHERE DATE(day_ts) BETWEEN start_date AND proc_date;
+WHERE DATE(day_ts) = proc_date;
 
 INSERT INTO `${PROJECT}.${DATASET}.sensor_readings_daily`
   (day_ts, native_sensor_id, metric_name, avg_value, min_value, max_value, samples)
@@ -33,5 +33,5 @@ SELECT
   MAX(value) AS max_value,
   COUNT(*) AS samples
 FROM `${PROJECT}.${DATASET}.sensor_readings_long`
-WHERE DATE(timestamp) BETWEEN start_date AND proc_date
+WHERE DATE(timestamp) = proc_date
 GROUP BY 1,2,3;

--- a/uv.lock
+++ b/uv.lock
@@ -239,6 +239,23 @@ wheels = [
 ]
 
 [[package]]
+name = "db-dtypes"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/c8/83fd7a11ef8d960da6c58d1a36b430b0a1818ae7a1da6efe887d96c35f40/db_dtypes-1.4.3.tar.gz", hash = "sha256:d3cb08c32939d24e05501f17694be8c1c54cfb4620d61fb56fb311e8c3d8885e", size = 33379, upload-time = "2025-05-12T13:54:21.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/91/66065d933b4814295fd0ddc16a66ef193dff14bf8d15895723f38640a3ab/db_dtypes-1.4.3-py3-none-any.whl", hash = "sha256:a1c92b819af947fae1701d80a71f2a0eac08f825ca52cf0c68aeba80577ae966", size = 18110, upload-time = "2025-05-12T13:54:20.146Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -252,7 +269,9 @@ name = "durham-environmental-monitoring"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "db-dtypes" },
     { name = "google-cloud-bigquery" },
+    { name = "google-cloud-bigquery-storage" },
     { name = "google-cloud-logging" },
     { name = "google-cloud-secret-manager" },
     { name = "google-cloud-storage" },
@@ -283,8 +302,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "db-dtypes", specifier = ">=1.2.0" },
     { name = "flake8", marker = "extra == 'dev'" },
     { name = "google-cloud-bigquery", specifier = ">=3.38.0" },
+    { name = "google-cloud-bigquery-storage", specifier = ">=2.25.0" },
     { name = "google-cloud-logging", specifier = ">=3.10.0" },
     { name = "google-cloud-secret-manager", specifier = ">=2.21.0" },
     { name = "google-cloud-storage", specifier = ">=2.18.2" },
@@ -443,6 +464,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/b2/a17e40afcf9487e3d17db5e36728ffe75c8d5671c46f419d7b6528a5728a/google_cloud_bigquery-3.38.0.tar.gz", hash = "sha256:8afcb7116f5eac849097a344eb8bfda78b7cfaae128e60e019193dd483873520", size = 503666, upload-time = "2025-09-17T20:33:33.47Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/3c/c8cada9ec282b29232ed9aed5a0b5cca6cf5367cb2ffa8ad0d2583d743f1/google_cloud_bigquery-3.38.0-py3-none-any.whl", hash = "sha256:e06e93ff7b245b239945ef59cb59616057598d369edac457ebf292bd61984da6", size = 259257, upload-time = "2025-09-17T20:33:31.404Z" },
+]
+
+[[package]]
+name = "google-cloud-bigquery-storage"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/5e/85869233deabd369b076486836f5d8389ac95a8ce692dd27cde767f89e2b/google_cloud_bigquery_storage-2.33.1.tar.gz", hash = "sha256:3fd25bef364ac5fb9bbd6560f0dd11b90b1845883df8e0a8c706ad53d00fc23b", size = 292622, upload-time = "2025-09-09T19:26:30.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/80/f4bb233912ab62b46b30618adbc840a02322a47c4f4f8a1e9f0494dac7db/google_cloud_bigquery_storage-2.33.1-py3-none-any.whl", hash = "sha256:24952aba0d69acc4d6bfbdc7a09dddbb728496b1780bd224f1056361a1b51044", size = 293619, upload-time = "2025-09-09T19:26:25.183Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changed from 7-day rolling window to single-day partition refresh.
This prevents permanent deletion of data older than 7 days.